### PR TITLE
Fix removal of django.core.serializers.python._get_model in Django 5.2

### DIFF
--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -20,12 +20,12 @@ def Deserializer(stream_or_string, **options):  # noqa
     """
     # Local imports to allow using modified versions of `_get_model` / `_get_model_from_node`
     # It could be patched in runtime via `unittest.mock.patch` for example
-    if django.VERSION >= (5, 2):
-        from django.core.serializers.python import Deserializer as PythonDeserializer
-
-        _get_model = PythonDeserializer._get_model_from_node
+    from django.core.serializers.python import Deserializer as PythonDeserializer
+    
+    if django.VERSION < (5, 2):
+        from django.core.serializers.python import _get_model
     else:
-        from django.core.serializers.python import Deserializer as PythonDeserializer, _get_model
+        _get_model = PythonDeserializer._get_model_from_node
 
     ignore = options.pop("ignorenonexistent", False)
 

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -21,7 +21,7 @@ def Deserializer(stream_or_string, **options):  # noqa
     # Local imports to allow using modified versions of `_get_model` / `_get_model_from_node`
     # It could be patched in runtime via `unittest.mock.patch` for example
     from django.core.serializers.python import Deserializer as PythonDeserializer
-    
+
     if django.VERSION < (5, 2):
         from django.core.serializers.python import _get_model
     else:

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -22,6 +22,7 @@ def Deserializer(stream_or_string, **options):  # noqa
     # It could be patched in runtime via `unittest.mock.patch` for example
     if django.VERSION >= (5, 2):
         from django.core.serializers.python import Deserializer as PythonDeserializer
+
         _get_model = PythonDeserializer._get_model_from_node
     else:
         from django.core.serializers.python import Deserializer as PythonDeserializer, _get_model

--- a/djmoney/serializers.py
+++ b/djmoney/serializers.py
@@ -1,6 +1,7 @@
 import json
 import sys
 
+import django
 from django.core.serializers.base import DeserializationError
 from django.core.serializers.json import Serializer as JSONSerializer
 
@@ -17,9 +18,13 @@ def Deserializer(stream_or_string, **options):  # noqa
     """
     Deserialize a stream or string of JSON data.
     """
-    # Local imports to allow using modified versions of `_get_model`
+    # Local imports to allow using modified versions of `_get_model` / `_get_model_from_node`
     # It could be patched in runtime via `unittest.mock.patch` for example
-    from django.core.serializers.python import Deserializer as PythonDeserializer, _get_model
+    if django.VERSION >= (5, 2):
+        from django.core.serializers.python import Deserializer as PythonDeserializer
+        _get_model = PythonDeserializer._get_model_from_node
+    else:
+        from django.core.serializers.python import Deserializer as PythonDeserializer, _get_model
 
     ignore = options.pop("ignorenonexistent", False)
 


### PR DESCRIPTION
Building on top of https://github.com/django-money/django-money/pull/786 to handle the 2nd incompatibility you spotted in https://github.com/django-money/django-money/issues/785